### PR TITLE
use new nanoc 3.3.0 module name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source :rubygems
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ install this gem:
 Then load it via your project Gemfile or in `./lib/default.rb`:
 
 ```ruby
-require 'nanoc3/cachebuster'
+require 'nanoc/cachebuster'
 ```
 
 Usage
@@ -51,7 +51,7 @@ And you rewrite the output of the file to include a fingerprint:
 
 ```ruby
 # in your ./lib/default.rb
-include Nanoc3::Helpers::CacheBusting
+include Nanoc::Helpers::CacheBusting
 # in ./Rules
 route '/styles/' do
   fp = fingerprint(item[:filename])

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,12 @@
+require 'bundler/setup'
+require 'bundler/gem_tasks'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+task :default => :spec
+
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
-require 'nanoc3/cachebuster/version'
-
-task :build do
-  sh 'gem build nanoc-cachebuster.gemspec'
-end
-
-desc 'Install the gem locally'
-task :install => :build do
-  sh "gem install nanoc-cachebuster-#{Nanoc3::Cachebuster::VERSION}.gem"
-end
-
-task :push do
-  sh 'git push origin master'
-  sh 'git push --tags'
-end
+require 'nanoc/cachebuster/version'
 
 task :log do
   changes = `git log --oneline $(git describe --abbrev=0 2>/dev/null)..HEAD`
@@ -23,7 +16,7 @@ task :log do
   path = File.expand_path('../HISTORY.md', __FILE__)
 
   original_content = File.read(path)
-  addition = "# #{Nanoc3::Cachebuster::VERSION}\n\n#{changes}"
+  addition = "# #{Nanoc::Cachebuster::VERSION}\n\n#{changes}"
   puts addition
 
   File.open(path, 'w') do |f|
@@ -31,14 +24,9 @@ task :log do
   end
 end
 
-desc 'Tag the code, push upstream, build and push the gem'
-task :release => [:install, :push] do
-  sh "gem push nanoc-cachebuster-#{Nanoc3::Cachebuster::VERSION}.gem"
-end
-
 desc 'Print current version number'
 task :version do
-  puts Nanoc3::Cachebuster::VERSION
+  puts Nanoc::Cachebuster::VERSION
 end
 
 class Version
@@ -60,7 +48,7 @@ class Version
   end
 
   def write
-    file = File.expand_path('../lib/nanoc3/cachebuster/version.rb', __FILE__)
+    file = File.expand_path('../lib/nanoc/cachebuster/version.rb', __FILE__)
     original_contents = File.read(file)
     File.open(file, 'w') do |f|
       f.write original_contents.gsub(/VERSION = ('|")\d+\.\d+\.\d+\1/, "VERSION = '#{to_s}'")
@@ -74,17 +62,17 @@ namespace :version do
   namespace :bump do
     desc 'Bump a major version'
     task :major do
-      Version.new(Nanoc3::Cachebuster::VERSION).bump(:major).write
+      Version.new(Nanoc::Cachebuster::VERSION).bump(:major).write
     end
 
     desc 'Bump a minor version'
     task :minor do
-      Version.new(Nanoc3::Cachebuster::VERSION).bump(:minor).write
+      Version.new(Nanoc::Cachebuster::VERSION).bump(:minor).write
     end
 
     desc 'Bump a patch version'
     task :patch do
-      Version.new(Nanoc3::Cachebuster::VERSION).bump(:patch).write
+      Version.new(Nanoc::Cachebuster::VERSION).bump(:patch).write
     end
   end
 end

--- a/lib/nanoc/cachebuster.rb
+++ b/lib/nanoc/cachebuster.rb
@@ -1,7 +1,7 @@
-require 'nanoc3'
+require 'nanoc'
 require 'digest'
 
-module Nanoc3
+module Nanoc
   module Cachebuster
     autoload :VERSION,  'cachebuster/version'
 

--- a/lib/nanoc/cachebuster/strategy.rb
+++ b/lib/nanoc/cachebuster/strategy.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 
-module Nanoc3
+module Nanoc
   module Cachebuster
     # The Strategy is a way to deal with an input file. The Cache busting filter
     # will use a strategy to process all references. You may want to use different
@@ -17,7 +17,7 @@ module Nanoc3
 
       def self.for(kind, site, item)
         klass = @subclasses[kind]
-        raise Nanoc3::Cachebuster::NoSuchStrategy.new "No strategy found for #{kind}" unless klass
+        raise Nanoc::Cachebuster::NoSuchStrategy.new "No strategy found for #{kind}" unless klass
         klass.new(site, item)
       end
 
@@ -28,12 +28,12 @@ module Nanoc3
       # future portability we might as well carry the entire site object
       # over.
       #
-      # @return <Nanoc3::Site>
+      # @return <Nanoc::Site>
       attr_reader :site
 
       # The Nanoc item we are currently filtering.
       #
-      # @return <Nanoc3::Item>
+      # @return <Nanoc::Item>
       attr_reader :current_item
 
       def initialize(site, current_item)
@@ -70,12 +70,12 @@ module Nanoc3
 
         matching_item = site.items.find do |i|
           next unless i.path # some items don't have an output path. Ignore those.
-          i.path.sub(/#{Nanoc3::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=\.)/o, '') == path
+          i.path.sub(/#{Nanoc::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=\.)/o, '') == path
         end
 
         # Raise an exception to indicate we should leave this reference alone
         unless matching_item
-          raise Nanoc3::Cachebuster::NoSuchSourceFile, 'No source file found matching ' + input_path
+          raise Nanoc::Cachebuster::NoSuchSourceFile, 'No source file found matching ' + input_path
         end
 
         # keep using an absolute path if the input reference did so...
@@ -124,7 +124,7 @@ module Nanoc3
         ('|"|)         # Then either a single, double or no quote at all
         (
           ([^'")]+)    # The file basename, and below the extension
-          \.(#{Nanoc3::Cachebuster::FILETYPES_TO_FINGERPRINT.join('|')})
+          \.(#{Nanoc::Cachebuster::FILETYPES_TO_FINGERPRINT.join('|')})
         )
         \1             # Repeat the same quote as at the start
         \)             # And cose the url()
@@ -146,7 +146,7 @@ module Nanoc3
         (                 # Capture the entire reference
           [^'"]+          # Anything but something that would close the attribute
                           # And then the extension:
-          (\.(?:#{Nanoc3::Cachebuster::FILETYPES_TO_FINGERPRINT.join('|')}))
+          (\.(?:#{Nanoc::Cachebuster::FILETYPES_TO_FINGERPRINT.join('|')}))
         )
         \2                # Repeat the opening quote
       /ix

--- a/lib/nanoc/cachebuster/version.rb
+++ b/lib/nanoc/cachebuster/version.rb
@@ -1,4 +1,4 @@
-module Nanoc3
+module Nanoc
   module Cachebuster
     VERSION = '0.1.0'
   end

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -1,0 +1,4 @@
+module Nanoc::Filters
+  autoload 'CacheBuster', 'nanoc/filters/cache_buster'
+  Nanoc::Filter.register '::Nanoc::Filters::CacheBuster', :cache_buster
+end

--- a/lib/nanoc/filters/cache_buster.rb
+++ b/lib/nanoc/filters/cache_buster.rb
@@ -1,15 +1,15 @@
-module Nanoc3
+module Nanoc
   module Filters
-    class CacheBuster < Nanoc3::Filter
+    class CacheBuster < Nanoc::Filter
       identifier :cache_buster
 
       def run(content, options = {})
         kind = options[:strategy] || (stylesheet? ? :css : :html)
-        strategy = Nanoc3::Cachebuster::Strategy.for(kind , site, item)
+        strategy = Nanoc::Cachebuster::Strategy.for(kind , site, item)
         content.gsub(strategy.class::REGEX) do |m|
           begin
             strategy.apply m, $1, $2, $3, $4
-          rescue Nanoc3::Cachebuster::NoSuchSourceFile
+          rescue Nanoc::Cachebuster::NoSuchSourceFile
             m
           end
         end
@@ -22,10 +22,10 @@ module Nanoc3
       # This is a simple check for filetypes, but you can override what strategy to use
       # with the filter options. This provides a default.
       #
-      # @see Nanoc3::Cachebuster::FILETYPES_CONSIDERED_CSS
+      # @see Nanoc::Cachebuster::FILETYPES_CONSIDERED_CSS
       # @return <Bool>
       def stylesheet?
-        Nanoc3::Cachebuster::FILETYPES_CONSIDERED_CSS.include?(item[:extension].to_s)
+        Nanoc::Cachebuster::FILETYPES_CONSIDERED_CSS.include?(item[:extension].to_s)
       end
     end
   end

--- a/lib/nanoc/helpers.rb
+++ b/lib/nanoc/helpers.rb
@@ -1,0 +1,3 @@
+module Nanoc::Helpers
+  autoload 'CacheBusting', 'nanoc/helpers/cache_busting'
+end

--- a/lib/nanoc/helpers/cache_busting.rb
+++ b/lib/nanoc/helpers/cache_busting.rb
@@ -1,4 +1,4 @@
-module Nanoc3
+module Nanoc
   module Helpers
     module CacheBusting
 
@@ -15,7 +15,7 @@ module Nanoc3
       # @param <Item> item is the item to test
       # @return <Boolean>
       def cachebust?(item)
-        Nanoc3::Cachebuster.should_apply_fingerprint_to_file?(item)
+        Nanoc::Cachebuster.should_apply_fingerprint_to_file?(item)
       end
 
       # Get a unique fingerprint for a file's content. This currently uses
@@ -25,7 +25,7 @@ module Nanoc3
       # @param <String> filename is the path to the file to fingerprint.
       # @return <String> file fingerprint
       def fingerprint(filename)
-        Nanoc3::Cachebuster.fingerprint_file(filename)
+        Nanoc::Cachebuster.fingerprint_file(filename)
       end
     end
   end

--- a/lib/nanoc3/filters.rb
+++ b/lib/nanoc3/filters.rb
@@ -1,4 +1,0 @@
-module Nanoc3::Filters
-  autoload 'CacheBuster', 'nanoc3/filters/cache_buster'
-  Nanoc3::Filter.register '::Nanoc3::Filters::CacheBuster', :cache_buster
-end

--- a/lib/nanoc3/helpers.rb
+++ b/lib/nanoc3/helpers.rb
@@ -1,3 +1,0 @@
-module Nanoc3::Helpers
-  autoload 'CacheBusting', 'nanoc3/helpers/cache_busting'
-end

--- a/nanoc-cachebuster.gemspec
+++ b/nanoc-cachebuster.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-require 'nanoc3/cachebuster/version'
+require 'nanoc/cachebuster/version'
 
 Gem::Specification.new do |s|
   s.name        = 'nanoc-cachebuster'
-  s.version     = Nanoc3::Cachebuster::VERSION
+  s.version     = Nanoc::Cachebuster::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Arjan van der Gaag']
   s.email       = ['arjan@arjanvandergaag.nl']
@@ -31,4 +31,8 @@ EOS
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
+  
+  s.add_runtime_dependency 'nanoc', '>= 3.3.0'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
 end

--- a/spec/nanoc/filters/cache_buster_spec.rb
+++ b/spec/nanoc/filters/cache_buster_spec.rb
@@ -44,12 +44,12 @@ class MockItem
   end
 end
 
-describe Nanoc3::Filters::CacheBuster do
+describe Nanoc::Filters::CacheBuster do
   before(:each) do
     Digest::MD5.stub!(:hexdigest).and_return('123456789')
   end
 
-  let(:subject) { Nanoc3::Filters::CacheBuster.new context }
+  let(:subject) { Nanoc::Filters::CacheBuster.new context }
   let(:content) { item.content }
   let(:item)    { MockItem.css_file }
   let(:target)  { MockItem.image_file }
@@ -65,7 +65,7 @@ describe Nanoc3::Filters::CacheBuster do
   end
 
   describe 'filter interface' do
-    it { should be_kind_of(Nanoc3::Filter) }
+    it { should be_kind_of(Nanoc::Filter) }
     it { should respond_to(:run) }
 
     it 'should accept a string and an options Hash' do

--- a/spec/nanoc/helpers/cache_busting_spec.rb
+++ b/spec/nanoc/helpers/cache_busting_spec.rb
@@ -1,7 +1,7 @@
-describe Nanoc3::Helpers::CacheBusting do
+describe Nanoc::Helpers::CacheBusting do
   let(:subject) do
     o = Object.new
-    o.extend Nanoc3::Helpers::CacheBusting
+    o.extend Nanoc::Helpers::CacheBusting
   end
 
   describe '#should_cachebust?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,1 @@
-require 'nanoc3/cachebuster'
-
+require 'nanoc/cachebuster'


### PR DESCRIPTION
I added the changes to be compatible with the new module namespace for the Nanoc 3.3.0 release. I also added some code for modern bundler/gem management.
