### PR TITLE
fix dependency collision with nanoc

### DIFF
--- a/lib/nanoc-cachebuster.rb
+++ b/lib/nanoc-cachebuster.rb
@@ -1,0 +1,1 @@
+require 'nanoc/cachebuster'

--- a/lib/nanoc/cachebuster.rb
+++ b/lib/nanoc/cachebuster.rb
@@ -1,9 +1,10 @@
 require 'nanoc'
 require 'digest'
 
+require 'nanoc/cachebuster/version'
+
 module Nanoc
   module Cachebuster
-    autoload :VERSION,  'cachebuster/version'
 
     # List of file extensions that the routing system should regard
     # as needing a fingerprint. These are input file extensions, so
@@ -38,7 +39,8 @@ module Nanoc
     end
   end
 
-  require File.expand_path('../filters', __FILE__)
-  require File.expand_path('../helpers', __FILE__)
-  require File.expand_path('../cachebuster/strategy', __FILE__)
 end
+
+require 'nanoc/cachebuster/strategy'
+require 'nanoc/filters/cache_buster'
+require 'nanoc/helpers/cache_busting'

--- a/lib/nanoc/cachebuster/strategy.rb
+++ b/lib/nanoc/cachebuster/strategy.rb
@@ -157,4 +157,3 @@ module Nanoc
     end
   end
 end
-

--- a/lib/nanoc/filters.rb
+++ b/lib/nanoc/filters.rb
@@ -1,4 +1,0 @@
-module Nanoc::Filters
-  autoload 'CacheBuster', 'nanoc/filters/cache_buster'
-  Nanoc::Filter.register '::Nanoc::Filters::CacheBuster', :cache_buster
-end

--- a/lib/nanoc/helpers.rb
+++ b/lib/nanoc/helpers.rb
@@ -1,3 +1,0 @@
-module Nanoc::Helpers
-  autoload 'CacheBusting', 'nanoc/helpers/cache_busting'
-end


### PR DESCRIPTION
After installing the new 0.2.0 gem I found a bug that didn't show up while testing pull #11.

The files `filters.rb` and `helpers.rb` were colliding with nanoc's files of the same names. I removed them (the `Nanoc::Filter.register` is no longer needed`) and normalized the require statements.
