### PR TITLE
Match retina images

### DIFF
--- a/lib/nanoc/cachebuster/strategy.rb
+++ b/lib/nanoc/cachebuster/strategy.rb
@@ -70,7 +70,7 @@ module Nanoc
 
         matching_item = site.items.find do |i|
           next unless i.path # some items don't have an output path. Ignore those.
-          i.path.sub(/#{Nanoc::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=\.)/o, '') == path
+          i.path.sub(/#{Nanoc::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=(@2x)?\.)/o, '') == path
         end
 
         # Raise an exception to indicate we should leave this reference alone


### PR DESCRIPTION
In my nanoc project, I need to use retina images (same image ending with @2x by convention, for use with Retina.js/a compass mixin). This is my rule:

```
route %r{/(images)/*/} do
  # cache-bust images
  if item.identifier.chop.end_with?('@2x')
    item.identifier.chop[0..-4] + fingerprint(item[:filename]) + '@2x.' + item[:extension]
  else
    item.identifier.chop + fingerprint(item[:filename]) + '.' + item[:extension]
  end
end
```

I needed to modify the CSS strategy to allow for matching Retina images. I'll try to write a cucumber test if I have time, but I'm on Windows at the moment and rspec doesn't like to play well on here. :(
