### PR TITLE
Fix cachebusting for png

### DIFF
--- a/lib/nanoc/cachebuster/strategy.rb
+++ b/lib/nanoc/cachebuster/strategy.rb
@@ -70,7 +70,7 @@ module Nanoc
 
         matching_item = site.items.find do |i|
           next unless i.path # some items don't have an output path. Ignore those.
-          i.path.sub(/#{Nanoc::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=(@2x)?\.)/o, '') == path
+          i.path.sub(/#{Nanoc::Cachebuster::CACHEBUSTER_PREFIX}[a-zA-Z0-9]{9}(?=\.)/o, '') == path
         end
 
         # Raise an exception to indicate we should leave this reference alone


### PR DESCRIPTION
It seems there's an issue where the fingerprint of a PNG file will always be 658e8dc0bf8b9a09b36994abf9242099, due to the way File.read works (see https://groups.google.com/forum/#!topic/asciidoc/SUsR8GcqZ08). This commit changes fingerprint_file to open the file in binary mode.

Note that this CL has the possibility of messing up peoples' existing workflow. Perhaps some additional logic can be done to avoid touching existing text files.
